### PR TITLE
ロード開始/終了コールバック (IScreenLoadHandler) の追加

### DIFF
--- a/Assets/ScreenSystem/Runtime/IScreenLoadHandler.cs
+++ b/Assets/ScreenSystem/Runtime/IScreenLoadHandler.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace ScreenSystem
+{
+    public enum ScreenKind
+    {
+        Page,
+        Modal,
+    }
+
+    public readonly struct ScreenLoadContext
+    {
+        public ScreenKind Kind { get; }
+        public Type ScreenType { get; }
+        public string PrefabName { get; }
+
+        public ScreenLoadContext(ScreenKind kind, Type screenType, string prefabName)
+        {
+            Kind = kind;
+            ScreenType = screenType;
+            PrefabName = prefabName;
+        }
+    }
+
+    public interface IScreenLoadHandler
+    {
+        void OnLoadStart(in ScreenLoadContext context);
+        void OnPrefabLoaded(in ScreenLoadContext context);
+        void OnLoadComplete(in ScreenLoadContext context);
+    }
+}

--- a/Assets/ScreenSystem/Runtime/IScreenLoadHandler.cs.meta
+++ b/Assets/ScreenSystem/Runtime/IScreenLoadHandler.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1f916e4db95a742dda2136b020555319

--- a/Assets/ScreenSystem/Runtime/Modal/ModalBuilderBase.cs
+++ b/Assets/ScreenSystem/Runtime/Modal/ModalBuilderBase.cs
@@ -25,9 +25,12 @@ namespace ScreenSystem.Modal
         {
             var nameAttr = Attribute.GetCustomAttribute(typeof(TModal), typeof(AssetNameAttribute)) as AssetNameAttribute;
             var source = new UniTaskCompletionSource<IModal>();
+            var prefabName = string.IsNullOrEmpty(_overridePrefabName) ? nameAttr.PrefabName : _overridePrefabName;
+            var loadHandler = ResolveScreenLoadHandler(parent);
+            var loadContext = new ScreenLoadContext(ScreenKind.Modal, typeof(TModal), prefabName);
+            loadHandler?.OnLoadStart(loadContext);
             using (LifetimeScope.EnqueueParent(parent))
             {
-                var prefabName = string.IsNullOrEmpty(_overridePrefabName) ? nameAttr.PrefabName : _overridePrefabName;
                 var modalTask = modalContainer.Push(prefabName, playAnimation: _playAnimation, onLoad: modal =>
                 {
                     if (cancellationToken.IsCancellationRequested)
@@ -41,17 +44,31 @@ namespace ScreenSystem.Modal
                     lts.Build();
                     var pageInstance = lts.Container.Resolve<TModal>();
                     source.TrySetResult(pageInstance);
+                    loadHandler?.OnPrefabLoaded(loadContext);
                 });
 
                 var modal = await source.Task;
                 await modalTask.Task;
                 cancellationToken.ThrowIfCancellationRequested();
+                loadHandler?.OnLoadComplete(loadContext);
                 return modal;
             }
         }
 
         protected virtual void SetUpParameter(LifetimeScope lifetimeScope)
         {
+        }
+
+        private static IScreenLoadHandler ResolveScreenLoadHandler(LifetimeScope parent)
+        {
+            try
+            {
+                return parent.Container.Resolve<IScreenLoadHandler>();
+            }
+            catch (VContainerException)
+            {
+                return null;
+            }
         }
     }
 

--- a/Assets/ScreenSystem/Runtime/Page/PageBuilderBase.cs
+++ b/Assets/ScreenSystem/Runtime/Page/PageBuilderBase.cs
@@ -28,9 +28,12 @@ namespace ScreenSystem.Page
         {
             var nameAttr = Attribute.GetCustomAttribute(typeof(TPage), typeof(AssetNameAttribute)) as AssetNameAttribute;
             var source = new UniTaskCompletionSource<IPage>();
+            var prefabName = string.IsNullOrEmpty(_overridePrefabName) ? nameAttr.PrefabName : _overridePrefabName;
+            var loadHandler = ResolveScreenLoadHandler(parent);
+            var loadContext = new ScreenLoadContext(ScreenKind.Page, typeof(TPage), prefabName);
+            loadHandler?.OnLoadStart(loadContext);
             using (LifetimeScope.EnqueueParent(parent))
             {
-                var prefabName = string.IsNullOrEmpty(_overridePrefabName) ? nameAttr.PrefabName : _overridePrefabName;
                 var pageTask = pageContainer.Push(prefabName, playAnimation: _playAnimation, stack: _isStack, onLoad: result =>
                 {
                     if (cancellationToken.IsCancellationRequested)
@@ -45,11 +48,13 @@ namespace ScreenSystem.Page
                     lts.Build();
                     var pageInstance = lts.Container.Resolve<TPage>();
                     source.TrySetResult(pageInstance);
+                    loadHandler?.OnPrefabLoaded(loadContext);
                 });
 
                 var page = await source.Task;
                 cancellationToken.ThrowIfCancellationRequested();
                 await pageTask.Task;
+                loadHandler?.OnLoadComplete(loadContext);
                 return page;
             }
         }
@@ -57,8 +62,20 @@ namespace ScreenSystem.Page
         protected virtual void SetUpParameter(LifetimeScope lifetimeScope)
         {
         }
+
+        private static IScreenLoadHandler ResolveScreenLoadHandler(LifetimeScope parent)
+        {
+            try
+            {
+                return parent.Container.Resolve<IScreenLoadHandler>();
+            }
+            catch (VContainerException)
+            {
+                return null;
+            }
+        }
     }
-    
+
     public abstract class PageBuilderBase<TPage, TPageView, TParameter> : PageBuilderBase<TPage, TPageView>
         where TPage : IPage
         where TPageView : PageViewBase


### PR DESCRIPTION
## Summary

- Page / Modal のロードライフサイクル前後で外部からフックできる `IScreenLoadHandler` を追加
- アプリ側でロード時間の計測やロギングを差し込めるようにすることが目的
- Handler 未登録時は完全 no-op、既存の利用コードには影響なし

## 変更内容

新規:
- `Assets/ScreenSystem/Runtime/IScreenLoadHandler.cs` — `IScreenLoadHandler` / `ScreenLoadContext` / `ScreenKind`

修正:
- `Assets/ScreenSystem/Runtime/Page/PageBuilderBase.cs` — `Build` 内で 3 点コールバックを発火
- `Assets/ScreenSystem/Runtime/Modal/ModalBuilderBase.cs` — 同上

`IPageBuilder` / `IModalBuilder` のシグネチャは変更していないので、既存呼び出しへの影響はゼロ。

## コールバック発火点

| メソッド | タイミング |
|---|---|
| `OnLoadStart` | `Build` 突入直後 |
| `OnPrefabLoaded` | `onLoad` 内で DI 構築完了直後（Prefab ロード時間の終端） |
| `OnLoadComplete` | `Push` タスクの await 後（アニメ含む Build 全体の終端） |

`Start → PrefabLoaded` で純粋なアセットロード時間、`Start → LoadComplete` でアニメ込みの全体時間をそれぞれ計測可能。

## Handler の解決方法

Builder は DI 対象ではないため、引数 `LifetimeScope parent` の `Container` から `Resolve<IScreenLoadHandler>()` を `try/catch (VContainerException)` で包んで任意解決している（VContainer 1.13 系には `TryResolve` が無いため）。

## 利用例

```csharp
public class ScreenLoadLogger : IScreenLoadHandler
{
    public void OnLoadStart(in ScreenLoadContext c)    => Debug.Log($"[Load Start] {c.Kind} {c.PrefabName}");
    public void OnPrefabLoaded(in ScreenLoadContext c) => Debug.Log($"[Prefab Loaded] {c.PrefabName}");
    public void OnLoadComplete(in ScreenLoadContext c) => Debug.Log($"[Load Complete] {c.PrefabName}");
}

// VContainer 登録
builder.Register<ScreenLoadLogger>(Lifetime.Singleton).AsImplementedInterfaces();
```

## Test plan

- [ ] Unity Editor でコンパイルが通ること
- [ ] 既存 `Assets/ScreenSystem/Tests` 配下のテストが通ること（Handler 未登録ケース）
- [ ] `IScreenLoadHandler` を DI 登録した状態で Page Push し、`OnLoadStart → OnPrefabLoaded → OnLoadComplete` の順に呼ばれることを確認
- [ ] Modal についても同様に確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)